### PR TITLE
feat(qinglong): 新建青龙脚本仓库骨架

### DIFF
--- a/qinglong/.github/workflows/lint.yml
+++ b/qinglong/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - 'qinglong/**'
+  pull_request:
+    paths:
+      - 'qinglong/**'
+
+jobs:
+  node-syntax-check:
+    name: Node Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check JS files
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          for f in qinglong/scripts/**/*.js; do
+            echo "==> Checking $f"
+            node --check "$f"
+          done
+
+  python-syntax-check:
+    name: Python Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Compile Python files
+        run: |
+          set -e
+          if compgen -G "qinglong/scripts/**/*.py" > /dev/null; then
+            python -m compileall -q qinglong/scripts
+          else
+            echo "No python scripts to check."
+          fi

--- a/qinglong/.gitignore
+++ b/qinglong/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.DS_Store
+*.log
+.env
+.env.local
+__pycache__/
+*.pyc
+.vscode/
+.idea/

--- a/qinglong/LICENSE
+++ b/qinglong/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 skyzhao1223
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/qinglong/README.md
+++ b/qinglong/README.md
@@ -1,0 +1,93 @@
+# 青龙脚本仓库（QingLong Scripts）
+
+> 本仓库用于集中管理 [青龙面板（QingLong Panel）](https://github.com/whyour/qinglong) 中运行的各类自动化脚本，方便统一拉取、订阅与维护。
+
+## 目录结构
+
+```text
+qinglong/
+├── scripts/              # 脚本主目录
+│   ├── jd/               # 京东相关脚本（签到、薅羊毛、互助等）
+│   ├── wskey/            # WSKey 转换 / Cookie 续期脚本
+│   └── utils/            # 通用工具脚本（通知、Cookie 校验等）
+├── dependence/           # 依赖文件（Node / Python / Shell）
+├── sub/                  # 青龙订阅配置示例
+├── docs/                 # 使用文档与说明
+└── .github/workflows/    # CI（语法检查 / 自动同步等）
+```
+
+## 一、在青龙面板中拉取本仓库
+
+> 假设你已将本仓库迁移/Fork 至自己的账号下，仓库地址形如 `https://github.com/<your-name>/qinglong-scripts.git`。
+
+### 方式 A：使用 `ql repo` 命令（推荐）
+
+进入青龙容器后执行：
+
+```bash
+ql repo https://github.com/<your-name>/qinglong-scripts.git \
+  "jd_|jx_|jddj_" \
+  "sign|backUp" \
+  "^jd[^_]|USER|utils|function|jdCookie" \
+  "main" \
+  "qinglong/scripts"
+```
+
+参数说明：
+
+| 位置 | 含义 |
+| --- | --- |
+| `$1` | 仓库地址 |
+| `$2` | 拉取脚本的正则白名单 |
+| `$3` | 拉取脚本的正则黑名单 |
+| `$4` | 拉取依赖文件的正则 |
+| `$5` | 分支名 |
+| `$6` | 仓库内的脚本路径（本仓库在 `qinglong/scripts` 子目录下） |
+
+### 方式 B：在「订阅管理」中导入
+
+打开 **青龙面板 → 订阅管理 → 新建订阅**，参考 `qinglong/sub/subscribe.example.json` 中的字段填写即可。
+
+## 二、Cookie 配置
+
+在青龙面板 **环境变量** 中按如下方式新增：
+
+| 变量名 | 含义 | 示例 |
+| --- | --- | --- |
+| `JD_COOKIE` | 京东账号 Cookie，多个账号用 `&` 分隔 | `pt_key=xxx;pt_pin=xxx;` |
+| `JD_DEBUG` | 调试日志开关 | `false` |
+| `PUSH_KEY` | Server 酱 Turbo 推送 Key | `SCT...` |
+| `BARK_PUSH` | Bark 推送地址 | `https://api.day.app/xxx` |
+
+> 推送相关变量可在 `qinglong/scripts/utils/sendNotify.js` 中查阅完整列表。
+
+## 三、定时规则
+
+每个脚本头部均带有「cron 表达式」与「new Env」声明，例如：
+
+```javascript
+/**
+ * 京东每日签到
+ * cron: 30 6,12 * * *
+ * new Env('京东每日签到');
+ */
+```
+
+青龙在拉库后会按头部声明自动添加定时任务，无需手动配置。
+
+## 四、贡献指南
+
+1. Fork 本仓库并创建特性分支：`git checkout -b feat/your-script`
+2. 在 `qinglong/scripts/<分类>/` 下添加脚本，文件名遵循 `jd_xxx.js`、`utils_xxx.py` 等规范
+3. 在脚本头部写明：`描述`、`cron`、`new Env(...)`、`作者`、`更新日期`
+4. 提交 PR 时附上脚本说明、所需环境变量、运行截图（可选）
+
+## 五、免责声明
+
+- 本仓库脚本仅供学习与研究使用，请勿用于商业用途
+- 使用脚本造成的账号风控、封禁等后果由使用者自行承担
+- 如脚本侵犯了您的权益，请通过 Issue 联系仓库维护者删除
+
+## License
+
+[MIT](./LICENSE)

--- a/qinglong/dependence/linux.txt
+++ b/qinglong/dependence/linux.txt
@@ -1,0 +1,2 @@
+bizCaCert
+lolcat

--- a/qinglong/dependence/package.txt
+++ b/qinglong/dependence/package.txt
@@ -1,0 +1,16 @@
+crypto-js
+got
+tough-cookie
+tslib
+ws@7.4.3
+ts-md5
+jsdom
+jsdom -g
+date-fns
+form-data
+json5
+global-agent
+png-js
+@types/node
+require
+typescript

--- a/qinglong/dependence/requirements.txt
+++ b/qinglong/dependence/requirements.txt
@@ -1,0 +1,5 @@
+requests
+canvas
+ping3
+jsonpath
+PyExecJS

--- a/qinglong/docs/CONTRIBUTING.md
+++ b/qinglong/docs/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# 编写规范
+
+## 1. 文件命名
+
+| 类型 | 命名约定 | 示例 |
+| --- | --- | --- |
+| 京东类脚本 | `jd_<功能>.js` | `jd_sign.js` |
+| WSKey 转换 | `wskey_<功能>.js` | `wskey_to_ck.js` |
+| 通用工具 | `utils_<功能>.{js,py}` 或放入 `scripts/utils/` | `sendNotify.js` |
+| Python 脚本 | 蛇形命名 | `check_cookies.py` |
+| Shell 脚本 | `<功能>.sh` | `backup.sh` |
+
+## 2. 头部注释（必填）
+
+每个脚本顶部都需要包含「描述、cron、new Env」三项，青龙才能自动识别并创建定时任务：
+
+```javascript
+/**
+ * 京东每日签到
+ *
+ * cron: 30 6,12 * * *
+ * new Env('京东每日签到');
+ */
+```
+
+```python
+"""京东每日签到
+
+cron: 30 6,12 * * *
+new Env('京东每日签到');
+"""
+```
+
+## 3. 环境变量
+
+- 优先复用现有变量（如 `JD_COOKIE`、`PUSH_KEY`）
+- 自定义变量统一使用 `大写下划线` 形式，并在 README 表格中登记
+- 在脚本内进行存在性判断与友好提示，避免 `undefined` 直接抛错
+
+## 4. 通知与日志
+
+- 业务输出走 `console.log` / `print`
+- 推送通知统一调用 `scripts/utils/sendNotify.js`
+- 不要在日志中明文输出 `pt_key` 等敏感字段，请使用 `maskPin` 等工具脱敏
+
+## 5. 依赖管理
+
+- Node 依赖追加到 `dependence/package.txt`
+- Python 依赖追加到 `dependence/requirements.txt`
+- 系统级依赖追加到 `dependence/linux.txt`
+
+## 6. 提交规范
+
+建议使用 Conventional Commits：
+
+| 前缀 | 用途 |
+| --- | --- |
+| `feat` | 新增脚本或功能 |
+| `fix` | 修复脚本 Bug |
+| `chore` | 依赖或配置变更 |
+| `docs` | 仅修改文档 |
+| `refactor` | 重构（无功能变化） |

--- a/qinglong/scripts/jd/jd_sign.js
+++ b/qinglong/scripts/jd/jd_sign.js
@@ -1,0 +1,83 @@
+/**
+ * 京东每日签到（示例脚本）
+ *
+ * 功能：调用京东 App 端「签到领京豆」接口，每日为账号签到一次。
+ * 仅作为青龙脚本目录结构与编写规范的示例，请在合规、合理的范围内使用。
+ *
+ * 环境变量：
+ *   JD_COOKIE   京东 Cookie，多账号用 & 分隔，必须包含 pt_key 与 pt_pin
+ *   JD_DEBUG    是否输出调试日志（true / false），默认 false
+ *
+ * cron: 30 6,12 * * *
+ * new Env('京东每日签到');
+ */
+
+const $ = new Env('京东每日签到');
+const notify = $.isNode() ? require('../utils/sendNotify') : '';
+const { requireCookies } = $.isNode() ? require('../utils/jdCookie') : { requireCookies: () => [] };
+
+const SIGN_API = 'https://api.m.jd.com/client.action?functionId=signBeanIndex';
+const UA =
+  'jdapp;iPhone;10.0.10;14.3;network/wifi;model/iPhone12,1;appBuild/167707;ADID/;supportApplePay/1;hasUPPay/0;pushNoticeIsOpen/1;hasOCPay/0;supportBestPay/0;session/30;pap/JA2019_3111789;brand/apple;Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/18C66';
+
+!(async () => {
+  const cookies = requireCookies();
+  if (!cookies.length) {
+    console.log('未检测到 JD_COOKIE，请在青龙环境变量中添加。');
+    return;
+  }
+
+  const messages = [];
+  for (let i = 0; i < cookies.length; i++) {
+    const ck = cookies[i];
+    const account = (ck.match(/pt_pin=([^;]+)/) || [, `账号${i + 1}`])[1];
+    try {
+      const result = await sign(ck);
+      messages.push(`【${decodeURIComponent(account)}】${result}`);
+    } catch (e) {
+      messages.push(`【${decodeURIComponent(account)}】签到失败：${e.message || e}`);
+    }
+  }
+
+  console.log('\n' + messages.join('\n'));
+  if (notify && notify.sendNotify) {
+    await notify.sendNotify($.name, messages.join('\n'));
+  }
+})()
+  .catch((err) => console.log(`运行异常：${err}`))
+  .finally(() => $.done());
+
+function sign(cookie) {
+  return new Promise((resolve, reject) => {
+    const headers = {
+      'User-Agent': UA,
+      Cookie: cookie,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    const body = 'body=%7B%22fp%22%3A%22-1%22%2C%22appid%22%3A%22ld%22%7D';
+
+    fetch(SIGN_API, { method: 'POST', headers, body })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data && data.code === '0' && data.data) {
+          const award = data.data.dailyAward || {};
+          resolve(`签到成功，获得 ${award.beanAward?.beanCount || 0} 京豆`);
+        } else {
+          reject(new Error(data && data.msg ? data.msg : JSON.stringify(data)));
+        }
+      })
+      .catch(reject);
+  });
+}
+
+// ========== Env 工具类（精简版，与青龙官方实现保持兼容） ==========
+function Env(name) {
+  this.name = name;
+  this.startTime = Date.now();
+  this.isNode = () => typeof module !== 'undefined' && !!module.exports;
+  this.log = (...args) => console.log(...args);
+  this.done = () => {
+    const cost = ((Date.now() - this.startTime) / 1000).toFixed(2);
+    console.log(`\n${this.name}, 耗时 ${cost} 秒`);
+  };
+}

--- a/qinglong/scripts/utils/check_cookies.py
+++ b/qinglong/scripts/utils/check_cookies.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""通用 Cookie 校验工具
+
+读取青龙环境变量 JD_COOKIE，按账号分组后输出脱敏后的 pt_pin 与剩余项数量，
+便于排查多账号配置是否正确。
+
+cron: 0 8 * * *
+new Env('Cookie 校验');
+"""
+
+import os
+import re
+import sys
+
+
+def parse_cookies(raw: str):
+    items = [c.strip() for c in re.split(r"[&\n]+", raw) if c.strip()]
+    return [c for c in items if "pt_key=" in c and "pt_pin=" in c]
+
+
+def mask_pin(cookie: str) -> str:
+    m = re.search(r"pt_pin=([^;]+)", cookie)
+    if not m:
+        return "未知账号"
+    pin = m.group(1)
+    if len(pin) <= 2:
+        return pin
+    return f"{pin[0]}***{pin[-1]}"
+
+
+def main() -> int:
+    raw = os.environ.get("JD_COOKIE", "")
+    if not raw.strip():
+        print("未检测到 JD_COOKIE，请在青龙环境变量中添加。")
+        return 1
+
+    cookies = parse_cookies(raw)
+    if not cookies:
+        print("JD_COOKIE 已配置，但解析后没有有效账号，请检查格式。")
+        return 1
+
+    print(f"共检测到 {len(cookies)} 个有效账号：")
+    for idx, ck in enumerate(cookies, 1):
+        print(f"  [{idx:>2}] pt_pin={mask_pin(ck)}  字段数={len(ck.split(';'))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qinglong/scripts/utils/jdCookie.js
+++ b/qinglong/scripts/utils/jdCookie.js
@@ -1,0 +1,26 @@
+/**
+ * 京东 Cookie 读取与校验工具
+ *
+ * 从青龙环境变量 JD_COOKIE 中读取多账号 Cookie，并执行最基本的格式校验。
+ * 其它脚本通过 require('./utils/jdCookie') 引入即可。
+ */
+
+function requireCookies() {
+  const raw = process.env.JD_COOKIE || '';
+  if (!raw.trim()) return [];
+
+  return raw
+    .split(/[&\n]/)
+    .map((c) => c.trim())
+    .filter((c) => /pt_key=/i.test(c) && /pt_pin=/i.test(c));
+}
+
+function maskPin(cookie) {
+  const m = cookie.match(/pt_pin=([^;]+)/);
+  if (!m) return '未知账号';
+  const pin = decodeURIComponent(m[1]);
+  if (pin.length <= 2) return pin;
+  return `${pin.slice(0, 1)}***${pin.slice(-1)}`;
+}
+
+module.exports = { requireCookies, maskPin };

--- a/qinglong/scripts/utils/sendNotify.js
+++ b/qinglong/scripts/utils/sendNotify.js
@@ -1,0 +1,99 @@
+/**
+ * 通用通知模块（精简版）
+ *
+ * 支持的渠道（按需在青龙环境变量中配置）：
+ *   - PUSH_KEY        Server 酱 Turbo
+ *   - BARK_PUSH       Bark
+ *   - TG_BOT_TOKEN    Telegram Bot Token
+ *   - TG_USER_ID      Telegram 接收用户 ID
+ *   - DD_BOT_TOKEN    钉钉机器人 token
+ *   - QYWX_KEY        企业微信群机器人 key
+ *
+ * 用法：
+ *   const { sendNotify } = require('./utils/sendNotify');
+ *   await sendNotify('标题', '正文');
+ */
+
+const https = require('https');
+const { URL } = require('url');
+
+function postJSON(url, data, extraHeaders = {}) {
+  return new Promise((resolve) => {
+    const u = new URL(url);
+    const body = typeof data === 'string' ? data : JSON.stringify(data);
+    const req = https.request(
+      {
+        method: 'POST',
+        hostname: u.hostname,
+        path: u.pathname + u.search,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...extraHeaders,
+        },
+      },
+      (res) => {
+        let chunks = '';
+        res.on('data', (c) => (chunks += c));
+        res.on('end', () => resolve(chunks));
+      },
+    );
+    req.on('error', () => resolve(''));
+    req.write(body);
+    req.end();
+  });
+}
+
+async function serverChan(title, content) {
+  const key = process.env.PUSH_KEY;
+  if (!key) return;
+  await postJSON(`https://sctapi.ftqq.com/${key}.send`, { title, desp: content });
+}
+
+async function bark(title, content) {
+  const url = process.env.BARK_PUSH;
+  if (!url) return;
+  await postJSON(`${url.replace(/\/$/, '')}/${encodeURIComponent(title)}/${encodeURIComponent(content)}`, {});
+}
+
+async function telegram(title, content) {
+  const token = process.env.TG_BOT_TOKEN;
+  const chatId = process.env.TG_USER_ID;
+  if (!token || !chatId) return;
+  await postJSON(`https://api.telegram.org/bot${token}/sendMessage`, {
+    chat_id: chatId,
+    text: `${title}\n${content}`,
+    disable_web_page_preview: true,
+  });
+}
+
+async function dingTalk(title, content) {
+  const token = process.env.DD_BOT_TOKEN;
+  if (!token) return;
+  await postJSON(`https://oapi.dingtalk.com/robot/send?access_token=${token}`, {
+    msgtype: 'text',
+    text: { content: `${title}\n${content}` },
+  });
+}
+
+async function workWechat(title, content) {
+  const key = process.env.QYWX_KEY;
+  if (!key) return;
+  await postJSON(`https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${key}`, {
+    msgtype: 'text',
+    text: { content: `${title}\n${content}` },
+  });
+}
+
+async function sendNotify(title, content) {
+  if (!title || !content) return;
+  await Promise.all([
+    serverChan(title, content),
+    bark(title, content),
+    telegram(title, content),
+    dingTalk(title, content),
+    workWechat(title, content),
+  ]);
+}
+
+module.exports = { sendNotify };

--- a/qinglong/sub/subscribe.example.json
+++ b/qinglong/sub/subscribe.example.json
@@ -1,0 +1,19 @@
+{
+  "name": "qinglong-scripts-subscribe-example",
+  "type": "public-repo",
+  "url": "https://github.com/<your-name>/qinglong-scripts.git",
+  "branch": "main",
+  "schedule": "0 0 */1 * *",
+  "alias": "qinglong-scripts",
+  "whitelist": "jd_|jx_|jddj_|utils_",
+  "blacklist": "sign|backUp",
+  "dependences": "^jd[^_]|USER|utils|function|jdCookie",
+  "extensions": "js py sh ts",
+  "sub_before": "echo '开始拉取 qinglong-scripts'",
+  "sub_after": "echo '拉取完成'",
+  "pull_type": "ssh-key",
+  "pull_option": {
+    "private_key": "~/.ssh/id_ed25519"
+  },
+  "remarks": "示例订阅配置，请按需修改 url、whitelist、blacklist 等字段"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

需要一个集中存储青龙（QingLong）脚本的仓库。由于 Cloud Agent 当前只能在该仓库内操作，无法直接在 GitHub 上创建一个全新仓库，因此先在本仓库的 `qinglong/` 子目录中搭建好完整骨架。后续你可以选择：

1. **作为子目录使用**：合并本 PR 后，直接 `ql repo` 拉取本仓库时把 `path` 参数指定为 `qinglong/scripts` 即可（README 已给出示例命令）。
2. **迁出为独立仓库**：在 GitHub 上手动创建空仓库 `qinglong-scripts`，然后将本目录迁移过去：
   ```bash
   git subtree split -P qinglong -b qinglong-only
   git push https://github.com/<your-name>/qinglong-scripts.git qinglong-only:main
   ```

## 目录结构

```text
qinglong/
├── README.md                 # 仓库说明 / 拉库命令 / 环境变量表
├── LICENSE                   # MIT
├── .gitignore
├── .github/workflows/
│   └── lint.yml              # Node + Python 语法检查 CI
├── docs/
│   └── CONTRIBUTING.md       # 命名、头部注释、依赖管理等规范
├── dependence/
│   ├── package.txt           # Node 依赖
│   ├── requirements.txt      # Python 依赖
│   └── linux.txt             # 系统级依赖
├── scripts/
│   ├── jd/
│   │   └── jd_sign.js        # 京东每日签到示例脚本
│   └── utils/
│       ├── jdCookie.js       # JD_COOKIE 解析与脱敏
│       ├── sendNotify.js     # 多渠道通知（Server酱 / Bark / TG / 钉钉 / 企微）
│       └── check_cookies.py  # Python 版 Cookie 校验
└── sub/
    └── subscribe.example.json # 订阅管理示例配置
```

## 关键点

- 所有示例脚本头部均含「描述 + cron + new Env」声明，可被青龙自动识别为定时任务
- `sendNotify.js` 仅依赖 Node 内置 `https`，无需额外安装即可工作
- CI 工作流对 `qinglong/scripts/**/*.js` 与 `*.py` 做语法检查，避免坏脚本被合入
- README 中给出了 `ql repo` 命令模板与所需环境变量表

## 验证

本地已对全部脚本做语法检查，均通过：

```text
OK: qinglong/scripts/jd/jd_sign.js
OK: qinglong/scripts/utils/jdCookie.js
OK: qinglong/scripts/utils/sendNotify.js
OK: check_cookies.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea5794fe-fc5c-4625-a89e-94a24f8856df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea5794fe-fc5c-4625-a89e-94a24f8856df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

